### PR TITLE
Prepare for Drupal 11 upgrade

### DIFF
--- a/access_request.info.yml
+++ b/access_request.info.yml
@@ -1,7 +1,7 @@
 name: 'Access Request'
 type: module
 description: 'Creates buttons to open MakeHaven doors at makehaven.org/access-request'
-core_version_requirement: ^10
+core_version_requirement: ^10 || ^11
 package: Custom
 dependencies:
   - views

--- a/src/Form/AccessRequestForm.php
+++ b/src/Form/AccessRequestForm.php
@@ -165,7 +165,7 @@ class AccessRequestForm extends FormBase {
     $current_user = \Drupal::currentUser();
     $uid = $current_user->id();
 
-    $user = \Drupal\user\Entity\User::load($uid);
+    $user = \Drupal::entityTypeManager()->getStorage('user')->load($uid);
     $card_id = $user->get('field_card_serial_number')->value;
 
     if (empty($card_id)) {


### PR DESCRIPTION
- Updated `core_version_requirement` to support Drupal 10 and 11.
- Replaced deprecated `\Drupal\user\Entity\User::load()` with the entity type manager service to ensure Drupal 11 compatibility.