### PR TITLE
Fix payload and consolidate asset configuration

### DIFF
--- a/config/install/access_request.settings.yml
+++ b/config/install/access_request.settings.yml
@@ -19,4 +19,3 @@ asset_map: |
     category: 'doors'
 dry_run: false
 user_block_field: ''
-door_map: ''

--- a/src/AccessRequestService.php
+++ b/src/AccessRequestService.php
@@ -45,14 +45,14 @@ class AccessRequestService {
       $source = preg_replace('/reader$/', '', $asset_identifier);
     }
 
-    $door_map_yaml = $this->config->get('door_map');
-    $door_map = Yaml::parse($door_map_yaml) ?? [];
-    $permission_id = $door_map[$asset_identifier] ?? $asset_identifier;
+    $asset_map_yaml = $this->config->get('asset_map');
+    $asset_map = Yaml::parse((string) $asset_map_yaml) ?? [];
+    $permission_id = $asset_map[$asset_identifier]['permission_id'] ?? $asset_identifier;
 
     $payload_array = [
       'uid' => $this->currentUser->id(),
       'email' => $this->currentUser->getEmail(),
-      'card_serial' => $card_id ?? '',
+      'card_id' => $card_id ?? '',
       'asset_identifier' => $asset_identifier,
       'reader_name' => $asset_identifier,
       'permission_id' => $permission_id,
@@ -118,7 +118,7 @@ class AccessRequestService {
       '@request_id' => $request_id,
       '@uid' => $payload_array['uid'],
       '@email' => $payload_array['email'],
-      '@card_serial' => $payload_array['card_serial'],
+      '@card_id' => $payload_array['card_id'],
       '@asset_id' => $payload_array['asset_identifier'],
       '@permission_id' => $payload_array['permission_id'],
     ];
@@ -172,7 +172,7 @@ class AccessRequestService {
     $log_context['@reason'] = $reason;
 
     $this->logger->info(
-      'Access request: request_id=@request_id, uid=@uid, email=@email, card_serial=@card_serial, asset_id=@asset_id, permission_id=@permission_id, http_status=@http_status, latency=@latency, result=@result, reason=@reason',
+      'Access request: request_id=@request_id, uid=@uid, email=@email, card_id=@card_id, asset_id=@asset_id, permission_id=@permission_id, http_status=@http_status, latency=@latency, result=@result, reason=@reason',
       $log_context
     );
 

--- a/src/Form/AccessRequestConfigForm.php
+++ b/src/Form/AccessRequestConfigForm.php
@@ -68,15 +68,8 @@ class AccessRequestConfigForm extends ConfigFormBase {
     $form['asset_map'] = [
       '#type' => 'textarea',
       '#title' => $this->t('Asset Map'),
-      '#description' => $this->t('A YAML mapping of asset IDs to asset information. The key for each asset is its unique ID.<br>Each asset has the following properties:<br>- <strong>name</strong>: The display name of the asset.<br>- <strong>description</strong>: A short description of the asset.<br>- <strong>image</strong>: The URL of an image for the asset (optional).<br>- <strong>category</strong>: A category for grouping assets (e.g., doors, metalshop).<br><br>Example:<br><code>backdoor:<br>&nbsp;&nbsp;name: Back Door<br>&nbsp;&nbsp;description: Main rear entrance.<br>&nbsp;&nbsp;image: /modules/custom/access_request/images/backdoor.jpg<br>&nbsp;&nbsp;category: doors</code>'),
+      '#description' => $this->t('A YAML mapping of asset IDs to asset information. The key for each asset is its unique ID.<br>Each asset has the following properties:<br>- <strong>name</strong>: The display name of the asset.<br>- <strong>description</strong>: A short description of the asset.<br>- <strong>image</strong>: The URL of an image for the asset (optional).<br>- <strong>category</strong>: A category for grouping assets (e.g., doors, metalshop).<br>- <strong>permission_id</strong>: The permission ID required for this asset (optional, defaults to the asset ID).<br><br>Example:<br><code>backdoor:<br>&nbsp;&nbsp;name: Back Door<br>&nbsp;&nbsp;description: Main rear entrance.<br>&nbsp;&nbsp;image: /modules/custom/access_request/images/backdoor.jpg<br>&nbsp;&nbsp;category: doors<br>&nbsp;&nbsp;permission_id: backdoor_permission</code>'),
       '#default_value' => $config->get('asset_map'),
-    ];
-
-    $form['door_map'] = [
-      '#type' => 'textarea',
-      '#title' => $this->t('Door Map'),
-      '#description' => $this->t('A YAML mapping of asset IDs to permission IDs.'),
-      '#default_value' => $config->get('door_map'),
     ];
 
     $form['dry_run'] = [
@@ -98,7 +91,6 @@ class AccessRequestConfigForm extends ConfigFormBase {
       ->set('timeout_seconds', $form_state->getValue('timeout_seconds'))
       ->set('web_hmac_secret', $form_state->getValue('web_hmac_secret'))
       ->set('asset_map', $form_state->getValue('asset_map'))
-      ->set('door_map', $form_state->getValue('door_map'))
       ->set('dry_run', $form_state->getValue('dry_run'))
       ->set('user_block_field', $form_state->getValue('user_block_field'))
       ->save();


### PR DESCRIPTION
This commit fixes a KeyError from the Python gateway by renaming `card_serial` to `card_id` in the request payload.

It also simplifies the module's configuration based on user feedback:
- The separate `door_map` configuration has been removed.
- The `asset_map` is now the single source of truth for asset configuration.
- `permission_id` can now be optionally specified for each asset within the `asset_map`. The service logic has been updated to read from this consolidated map.